### PR TITLE
fix: emit nested JS function declarations once

### DIFF
--- a/polyscan/internal/js/analyzer/cfg_builder.go
+++ b/polyscan/internal/js/analyzer/cfg_builder.go
@@ -127,6 +127,40 @@ func resolveFunctionName(node *parser.Node) string {
 	return fmt.Sprintf("anonymous_%d", node.Location.StartLine)
 }
 
+func functionLocationKey(n *parser.Node) string {
+	return fmt.Sprintf("%d:%d", n.Location.StartLine, n.Location.StartCol)
+}
+
+func recordFunctionLocations(cfgs map[string]*CFG, discovered map[string]bool) {
+	for _, cfg := range cfgs {
+		if cfg == nil {
+			continue
+		}
+		for _, block := range cfg.Blocks {
+			for _, value := range block.Statements {
+				stmt, ok := jsNode(value)
+				if !ok {
+					continue
+				}
+				if stmt.IsFunction() {
+					discovered[functionLocationKey(stmt)] = true
+				}
+			}
+		}
+	}
+}
+
+func (b *CFGBuilder) mergeNestedFunctionCFGs(src *CFGBuilder) {
+	if src == nil {
+		return
+	}
+	for name, cfg := range src.functionCFGs {
+		if _, exists := b.functionCFGs[name]; !exists {
+			b.functionCFGs[name] = cfg
+		}
+	}
+}
+
 // BuildAll builds CFGs for all functions in the AST
 func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 	if node == nil {
@@ -151,20 +185,7 @@ func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 	// Scan all blocks (not just Entry) because processStatement may place
 	// function nodes inside control-flow blocks (if_then, loop_body, etc.).
 	discoveredLocations := make(map[string]bool)
-	for _, cfg := range allCFGs {
-		for _, block := range cfg.Blocks {
-			for _, value := range block.Statements {
-				stmt, ok := jsNode(value)
-				if !ok {
-					continue
-				}
-				if stmt.IsFunction() {
-					key := fmt.Sprintf("%d:%d", stmt.Location.StartLine, stmt.Location.StartCol)
-					discoveredLocations[key] = true
-				}
-			}
-		}
-	}
+	recordFunctionLocations(allCFGs, discoveredLocations)
 
 	// Discover functions nested inside expressions (variable declarations,
 	// assignments, callbacks, object methods, etc.) that processStatement
@@ -179,10 +200,12 @@ func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 
 		funcName := resolveFunctionName(n)
 
-		// Skip if already discovered
+		// Skip if already discovered. Return false so we do not re-walk
+		// the body: nested declarations were merged from the builder that
+		// first produced this CFG (processStatement / earlier walk).
 		locationKey := fmt.Sprintf("%d:%d", n.Location.StartLine, n.Location.StartCol)
 		if discoveredLocations[locationKey] {
-			return true
+			return false
 		}
 		discoveredLocations[locationKey] = true
 
@@ -208,6 +231,8 @@ func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 					allCFGs[nestedName] = nestedCFG
 				}
 			}
+			recordFunctionLocations(map[string]*CFG{funcName: funcCFG}, discoveredLocations)
+			recordFunctionLocations(funcBuilder.functionCFGs, discoveredLocations)
 		}
 		return false // Don't descend into this function's body (Build handles it)
 	})
@@ -253,6 +278,7 @@ func (b *CFGBuilder) buildClass(node *parser.Node) {
 			if err == nil {
 				fullName := node.Name + "." + methodName
 				b.functionCFGs[fullName] = methodCFG
+				b.mergeNestedFunctionCFGs(funcBuilder)
 			}
 		}
 	}
@@ -300,6 +326,10 @@ func (b *CFGBuilder) processStatement(node *parser.Node) {
 		funcCFG, err := funcBuilder.Build(node)
 		if err == nil {
 			b.functionCFGs[funcName] = funcCFG
+			// Keep declarations nested inside this function; otherwise
+			// BuildAll marks their locations as discovered from Statements
+			// and never rebuilds them.
+			b.mergeNestedFunctionCFGs(funcBuilder)
 		}
 
 		// Add function expression as statement in current block

--- a/polyscan/internal/js/analyzer/cfg_builder_test.go
+++ b/polyscan/internal/js/analyzer/cfg_builder_test.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
@@ -834,6 +835,49 @@ func TestCFGBuilder_Build_Class(t *testing.T) {
 
 	if cfg.Name != "Calculator" {
 		t.Errorf("CFG name should be 'Calculator', got %s", cfg.Name)
+	}
+}
+
+func TestCFGBuilder_BuildAll_NestedFunctionDeclarations(t *testing.T) {
+	// Repro for nested function declarations dropped (inside a named
+	// function) or duplicated as name_<line> (inside arrows/methods).
+	code := `
+const arrow = () => {
+  function inArrow(x) { if (x) { return 1; } return 0; }
+  return inArrow(1);
+};
+class K {
+  m() {
+    function inMethod(x) { if (x) { return 1; } return 0; }
+    return inMethod(1);
+  }
+}
+function named() {
+  function inNamed(x) { if (x) { return 1; } return 0; }
+  return inNamed(1);
+}
+`
+	ast := parseJS(t, code)
+	builder := NewCFGBuilder()
+	cfgs, err := builder.BuildAll(ast)
+	if err != nil {
+		t.Fatalf("BuildAll failed: %v", err)
+	}
+
+	names := make([]string, 0, len(cfgs))
+	for name := range cfgs {
+		names = append(names, name)
+	}
+
+	for _, want := range []string{"inArrow", "inMethod", "inNamed", "m", "named"} {
+		if cfgs[want] == nil {
+			t.Errorf("missing CFG %q; have %v", want, names)
+		}
+	}
+	for _, name := range names {
+		if strings.HasPrefix(name, "inArrow_") || strings.HasPrefix(name, "inMethod_") || strings.HasPrefix(name, "inNamed_") {
+			t.Errorf("duplicate suffixed CFG %q; have %v", name, names)
+		}
 	}
 }
 

--- a/polyscan/internal/js/parser/ast.go
+++ b/polyscan/internal/js/parser/ast.go
@@ -222,7 +222,9 @@ func (n *Node) AddChild(child *Node) {
 }
 
 // Walk traverses the AST depth-first and calls the visitor function for each node
-// If the visitor returns false, traversal of that branch is stopped
+// If the visitor returns false, traversal of that branch is stopped.
+// The same child pointer is not visited twice: ast_builder stores some
+// statements on both Children and Body (and similar overlapping fields).
 func (n *Node) Walk(visitor func(*Node) bool) {
 	if n == nil {
 		return
@@ -232,80 +234,59 @@ func (n *Node) Walk(visitor func(*Node) bool) {
 		return
 	}
 
-	for _, child := range n.Children {
+	seen := map[*Node]struct{}{}
+	walk := func(child *Node) {
+		if child == nil {
+			return
+		}
+		if _, ok := seen[child]; ok {
+			return
+		}
+		seen[child] = struct{}{}
 		child.Walk(visitor)
 	}
+
+	for _, child := range n.Children {
+		walk(child)
+	}
 	for _, param := range n.Params {
-		param.Walk(visitor)
+		walk(param)
 	}
 	for _, stmt := range n.Body {
-		stmt.Walk(visitor)
+		walk(stmt)
 	}
 	for _, caseNode := range n.Cases {
-		caseNode.Walk(visitor)
+		walk(caseNode)
 	}
 	for _, handler := range n.Handlers {
-		handler.Walk(visitor)
+		walk(handler)
 	}
 	for _, arg := range n.Arguments {
-		arg.Walk(visitor)
+		walk(arg)
 	}
 	for _, decl := range n.Declarations {
-		decl.Walk(visitor)
+		walk(decl)
 	}
 	for _, spec := range n.Specifiers {
-		spec.Walk(visitor)
+		walk(spec)
 	}
 
-	// Walk individual nodes
-	if n.Test != nil {
-		n.Test.Walk(visitor)
-	}
-	if n.Consequent != nil {
-		n.Consequent.Walk(visitor)
-	}
-	if n.Alternate != nil {
-		n.Alternate.Walk(visitor)
-	}
-	if n.Init != nil {
-		n.Init.Walk(visitor)
-	}
-	if n.Update != nil {
-		n.Update.Walk(visitor)
-	}
-	if n.Handler != nil {
-		n.Handler.Walk(visitor)
-	}
-	if n.Finalizer != nil {
-		n.Finalizer.Walk(visitor)
-	}
-	if n.Left != nil {
-		n.Left.Walk(visitor)
-	}
-	if n.Right != nil {
-		n.Right.Walk(visitor)
-	}
-	if n.Argument != nil {
-		n.Argument.Walk(visitor)
-	}
-	if n.Callee != nil {
-		n.Callee.Walk(visitor)
-	}
-	if n.Object != nil {
-		n.Object.Walk(visitor)
-	}
-	if n.Property != nil {
-		n.Property.Walk(visitor)
-	}
-	if n.Source != nil {
-		n.Source.Walk(visitor)
-	}
-	if n.Declaration != nil {
-		n.Declaration.Walk(visitor)
-	}
-	if n.TypeAnnotation != nil {
-		n.TypeAnnotation.Walk(visitor)
-	}
+	walk(n.Test)
+	walk(n.Consequent)
+	walk(n.Alternate)
+	walk(n.Init)
+	walk(n.Update)
+	walk(n.Handler)
+	walk(n.Finalizer)
+	walk(n.Left)
+	walk(n.Right)
+	walk(n.Argument)
+	walk(n.Callee)
+	walk(n.Object)
+	walk(n.Property)
+	walk(n.Source)
+	walk(n.Declaration)
+	walk(n.TypeAnnotation)
 }
 
 // GetChildren returns all child nodes in the parser's canonical order.

--- a/polyscan/internal/js/parser/parser_test.go
+++ b/polyscan/internal/js/parser/parser_test.go
@@ -884,6 +884,25 @@ func TestNode_Walk_Nil(t *testing.T) {
 	})
 }
 
+func TestNode_Walk_SkipsBodyDuplicates(t *testing.T) {
+	parent := NewNode(NodeProgram)
+	child := NewNode(NodeFunction)
+	child.Name = "fn"
+	parent.AddChild(child)
+	parent.Body = append(parent.Body, child)
+
+	visited := 0
+	parent.Walk(func(n *Node) bool {
+		if n.Name == "fn" {
+			visited++
+		}
+		return true
+	})
+	if visited != 1 {
+		t.Errorf("expected fn visited once, got %d", visited)
+	}
+}
+
 func TestNode_Walk_StopTraversal(t *testing.T) {
 	parent := NewNode(NodeProgram)
 	child1 := NewNode(NodeFunction)


### PR DESCRIPTION
Fixes #135

Nested function declarations inside a named function were dropped (CFG stored only the outer function). Nested declarations inside arrows/methods were emitted twice as name and name_<line> because Walk visited Children and Body and BuildAll re-descended discovered functions.

processStatement now keeps nested CFGs; Walk skips duplicate child pointers; BuildAll does not re-walk a function it already built.

`go test ./internal/js/... ./internal/analysis/ -count=1` passes.